### PR TITLE
Digital Toolbox: Management post and site UI refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,62 @@
+# AGENTS.md — michaelconan.github.io
+
+## Project Summary
+
+This is a personal Jekyll / GitHub Pages site for Michael Conan — a technology consultant at PwC Dublin, originally from Portland, Oregon. The site is deployed from the `docs/` directory via the `gh-pages` branch and uses the Cayman remote theme.
+
+**Structure:**
+- `docs/` — Jekyll site root (served by GitHub Pages)
+  - `_posts/` — published blog posts (filename format: `YYYY-MM-DD-slug.md`)
+  - `_drafts/` — unpublished draft posts
+  - `_data/` — structured YAML data (profiles, projects, navigation)
+  - `_includes/` — custom HTML includes (e.g. `head-custom.html`)
+  - `assets/css/style.scss` — custom CSS overriding the Cayman theme
+  - `index.md` — home/about page
+  - `blog.md` — blog listing with Google Form + Substack subscription iframes
+  - `profile.md` — professional background and skills
+  - `projects.md` — auto-populated from GitHub public repos via `jekyll-github-metadata`
+- `subscription/` — Google Apps Script for email subscription notifications
+- `Makefile` — build/serve shortcuts
+
+**Content tone:** Personal, reflective, British English spellings (the author lives in Dublin). Posts cover personal life, travel, family, faith, and technology. Tech posts often relate to the author's consulting work with data, AI, automation, and personal productivity tooling (Jira, HubSpot, Notion).
+
+---
+
+## How Agents Should Help
+
+### Blog Post Revision
+
+When revising or drafting blog posts in `docs/_posts/` or `docs/_drafts/`:
+
+- **Preserve voice:** Michael's writing is measured, thoughtful, and personal. Avoid adding enthusiasm, hype, or listicle patterns not already present.
+- **British English:** Use British spellings and conventions (e.g. *organised*, *colour*, *practise* (verb), *programme*). The author is American-born but writes in British English.
+- **Front matter:** Every published post requires front matter with at minimum `layout: post`, `title`, `categories`, and ideally `description` and `tags`. The `layout` line is sometimes commented out in drafts — un-comment it when publishing.
+- **Categories and tags:** Posts are grouped by category on the blog page. Existing categories include `personal` and `tech`. Tags can be freeform.
+- **Filename convention:** `YYYY-MM-DD-kebab-case-title.md` — use the actual publish date.
+- **Do not add emojis** unless they already appear in the draft title or body.
+- **Excerpts:** Jekyll uses the first paragraph as the excerpt shown on the blog listing. Keep the opening paragraph tight and representative.
+
+### Site Enhancement
+
+When making changes to the site layout, styles, or content pages:
+
+- **Theme:** The site uses `pages-themes/cayman@v0.2.0` as a remote theme. Custom overrides go in `assets/css/style.scss` and `_includes/head-custom.html`. Avoid forking the theme.
+- **CSS:** The custom stylesheet extends the Cayman base. Keep additions scoped and minimal.
+- **Navigation and data:** Site navigation and profile links are driven by YAML in `docs/_data/`. Prefer editing data files over hardcoding values in layouts.
+- **Subscription mechanism:** The email subscription flow uses a Google Form embedded as an iframe in `blog.md`. Do not replace or remove this without confirming with the author.
+- **Jekyll plugins:** Only plugins whitelisted by GitHub Pages are available in production. Do not add arbitrary plugins without verifying compatibility.
+- **Local testing:** Navigate to `docs/` and run `bundle exec jekyll serve`. Set `JEKYLL_GITHUB_TOKEN` for the `site.github` metadata to resolve locally.
+
+### Git and PR Workflow
+
+- The site is deployed from the **`gh-pages`** branch (default branch).
+- Feature branches should be opened as PRs targeting `gh-pages`, not `main`.
+- Commit messages should be short and descriptive. Prefix with a conventional type where it fits: `feat:`, `fix:`, `content:`, `style:`, `chore:`.
+- Do not push directly to `gh-pages`.
+
+### What to Avoid
+
+- Do not rewrite or substantially restructure posts without explicit instruction.
+- Do not change the author's personal details or opinions in text.
+- Do not add tracking scripts, third-party embeds, or external dependencies without confirmation.
+- Do not alter the subscription iframes or Google Analytics configuration.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/docs/_includes/head-custom.html
+++ b/docs/_includes/head-custom.html
@@ -16,19 +16,16 @@
 
 {% include google-analytics.html %}
 
-<!-- Navigation bar from _data/navigation.yml definition -->
-<nav class="page-navigation" aria-label="Page navigation">
+<!-- Navigation bar from _data/content.yml definition -->
+<nav class="page-navigation" aria-label="Site navigation">
   <ul>
-    {% for nav in site.data.content.navigation %} {% if nav.title == page.title
-    or (nav.title == "Home" and page.url == "/") %}
-    <li class="active">
-      <a href="{{ nav.url }}" target="_top">{{ nav.title }}</a>
-    </li>
-    {% else %}
-    <li>
-      <a href="{{ site.url }}{{ nav.href }}" target="_top">{{ nav.title }}</a>
-    </li>
-    {% endif %} {% endfor %}
+    {% for nav in site.data.content.navigation %}
+      {% if nav.title == page.title or (nav.title == "Home" and page.url == "/") %}
+        <li class="active"><a href="{{ nav.href }}" target="_top">{{ nav.title }}</a></li>
+      {% else %}
+        <li><a href="{{ nav.href }}" target="_top">{{ nav.title }}</a></li>
+      {% endif %}
+    {% endfor %}
   </ul>
 </nav>
 

--- a/docs/_posts/2026-03-14-digital-toolbox-management.md
+++ b/docs/_posts/2026-03-14-digital-toolbox-management.md
@@ -1,0 +1,77 @@
+---
+# layout: post
+title: '💻 Digital Toolbox: Management'
+description: "How I use Jira, HubSpot, and Notion to stay organised across work and life — and what I'm building on top of them."
+categories: tech
+tags: tech agents
+---
+
+As I grow in life and career, I have come to appreciate the value of productivity and management applications — not just at work, but across every area of life.
+
+As a consultant, I work across multiple clients, frequently needing to quickly learn and adapt to their curated portfolio of technologies. While some tools have clear advantages over others, in most cases it is knowledge and experience that determine how much value you actually get out of any given one. By adopting a suite of these tools for my own personal use, I aim to improve organisation, increase productivity, and become a more effective user of technology in both work and life.
+
+## Management Toolbox
+
+My set of tools has grown and shifted over time, and has settled — for now — on the following selection.
+
+### Personal Project Management
+
+For years, my tasks and to-dos were scattered across a mix of digital and physical mediums. They would often get lost or left behind, and I struggled to consistently prioritise and schedule work over time.
+
+In consulting programmes, we typically organise work into task hierarchies and execute them across sprint cycles. While I rarely dedicate enough personal time to my own projects to run strict 1–2 week sprints, I have adopted a monthly rhythm for tracking and completing recurring, seasonal, and ad-hoc tasks.
+
+For more collaborative and structured project tracking, the tools I have used across various roles span a few categories:
+
+- **Spreadsheets:** A natural starting point, but not my preference. There is always a trade-off between keeping things simple in Excel and leveraging the features of a purpose-built application — a balance worth considering carefully. Ultimately, the most important factor is not the tool itself, but how you use it.
+- **Structured List Applications:** There are many lightweight options for structured lists available within tools like SharePoint and Slack. More dedicated options in this category — such as Asana or Microsoft Planner — can strike a useful balance: enough structure and reporting functionality to be meaningful, without the overhead of a full project suite.
+- **Full-Featured Project Suites:** For larger, more complex projects, a proper project suite makes a significant difference. I have the most experience with Azure Boards and GitHub Projects, both of which are particularly well-suited to technical and software work. My current employer has also developed their own agile project tool, designed around our consulting methodologies and integrated across our internal applications.
+
+For my own personal projects, I chose Jira Cloud — a widely-used tool with a generous free tier and a functional mobile app. I break work down into stories, tasks, and subtasks, linking them to epics that support my broader goals for the year.
+
+### Community Relationship Management
+
+In work and life, maintaining relationships can become genuinely challenging, and many naturally ebb and flow with distance and time. Businesses address this with customer relationships through CRM systems, used to track contacts, companies, deals, meetings, and more. Reflecting on this — particularly after moving a significant distance from most of my lifelong friends and family — I realised a similar approach could help me be more intentional about staying connected.
+
+HubSpot offers a free tier, and I began adapting its features for personal use:
+
+- **Contacts:** As a first step, I imported a number of my personal and professional connections using Google Contact sync with a tag filter, then mapped them to "companies" based on the community circles I maintain — setting goals around how frequently I want to connect with individuals in each.
+- **Engagements:** The feature I use most is engagement logging — recording meetings, calls, and other interactions. This helps me track progress against my connection targets and maintain notes on conversations to follow up on or add to my prayer list.
+- **Tickets and Deals:** I have also adapted some of HubSpot's other functionality for personal use: tickets to track ongoing situations where I am supporting someone, and deals to manage planning around joint travel and upcoming visits with friends and family.
+
+It can feel a little clinical to track personal relationships in a CRM. In practice, though, I have found it genuinely helpful for being more intentional and staying meaningfully connected with those I care about.
+
+### Knowledge, Habits, and… Anything
+
+Like my tasks, I have historically kept notes and documents scattered across many different systems, most of which offered limited structure or discoverability.
+
+Over the past couple of years, I have adopted Notion — and found it to be an excellent blend of document repository, structured data store, and general knowledge base.
+
+I currently use it in a few key ways:
+
+- **Habit Tracking:** One of my first Notion use cases was building databases to track daily, weekly, and monthly habits. Much of the native automation is limited or paywalled, but the API is well-documented and easy to work with.
+- **Knowledge Management:** Keeping track of technology, finances, training, and ongoing learning has often been a challenge, leading to note sprawl across various apps. Notion's page hierarchy has allowed me to centralise and organise this information in a way that is easy to search and navigate.
+- **Structured Lists:** Notion's databases are flexible and extensible. I use them to capture trips and related bookings, training courses, recurring purchases, and even the blogs I write. They are easy to sort and filter for regular use, though built-in reporting is somewhat limited — more on that shortly.
+
+The flexibility and structure of Notion as a workspace tool has made it remarkably useful across many areas of my life. The team has also been expanding the product to include Calendar and Email features, which are still early in development but already offer a number of helpful touches.
+
+## Connected Tools
+
+Much of the value in adopting modern cloud-based tools — particularly given my focus on data and AI — exists not within the applications themselves, but in the analytics and AI layer built on top of them.
+
+### Integration and Reporting
+
+Over the past year or so, I have been building a [personal data warehouse](https://github.com/michaelconan/personal-reporting-pipelines) on top of this tool suite using a combination of open-source and affordable cloud technologies. I am currently refining the process of ingesting data from each tool's API into Google BigQuery using dlt (data load tool), then transforming it with dbt (data build tool). Once that is in place, I plan to build a Streamlit dashboard to visualise the data and track progress against my personal goals.
+
+### AI Agents
+
+Beyond reporting, I have found that modern AI applications — like Perplexity and Claude — can integrate directly with these tools to automate steps in my workflow. A few recent examples:
+
+- Adding booking details to Notion databases from email confirmations
+- Updating HubSpot deal status and notes
+- Adding Jira tasks to an active sprint
+
+Most of what I have delegated to agents so far has been relatively small in scope, but a quick voice prompt has consistently saved a meaningful amount of manual clicking and typing. I plan to experiment further with more complex, multi-step workflows across applications.
+
+## Reflections
+
+In an increasingly digital world, it is easy to get swept up in the ever-growing list of tools promising to save you time and simplify your life. My recommendation is to explore and adopt them — but to do so deliberately. Take the time to define clearly how you intend to use each tool and what benefit you expect to get from it. The right tool, used with purpose, can make a real difference; the wrong one, adopted without intention, just adds noise.

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -7,64 +7,211 @@
   padding: 10px 4rem;
 }
 
+.main-content h1,
+.main-content h2,
+.main-content h3,
+.main-content h4 {
+  margin-top: 1.5rem;
+}
+
 .my-button {
     display: inline-block;
-    padding: 8px 20px;
-    background-color: #159957; /* A green shade */
+    padding: 10px 24px;
+    background-color: #159957;
     color: white;
     text-align: center;
     text-decoration: none;
     border: none;
     border-radius: 4px;
-    font-size: 16px;
-    transition: background-color 0.3s ease;
-
-    /* Adding a box-shadow for a subtle depth effect */
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+    font-size: 15px;
+    font-weight: 600;
+    letter-spacing: 0.3px;
+    transition: background-color 0.2s ease, box-shadow 0.2s ease;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
+    margin: 4px 6px 4px 0;
 }
 
 .my-button:hover, .my-button:focus {
-    background-color: #0c7b43; /* A darker green for hover/focus */
+    background-color: #0c7b43;
     text-decoration: none;
     color: white;
+    box-shadow: 0 3px 8px rgba(0, 0, 0, 0.25);
 }
 
+.my-button-secondary {
+    background-color: #155799;
+}
+
+.my-button-secondary:hover, .my-button-secondary:focus {
+    background-color: #0e3f70;
+}
+
+/* Navigation bar */
 .page-navigation {
   display: flex;
-  justify-content: space-between;
+  align-items: center;
+  padding: 0 2rem;
+  background-color: #2b2b2b;
+  border-bottom: 3px solid #159957;
   list-style: none;
-  padding: 10px;
-  background-color: #333;
 }
 
 .page-navigation ul {
   margin: 0;
   padding: 0;
   display: flex;
+  flex-wrap: wrap;
 }
 
 .page-navigation li {
-  margin-right: 15px;
   list-style-type: none;
 }
 
 .page-navigation a {
-  color: white;
+  display: block;
+  padding: 14px 16px;
+  color: #e0e0e0;
   text-decoration: none;
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: 0.4px;
+  transition: color 0.2s ease, background-color 0.2s ease;
 }
 
 .page-navigation a:hover {
-  text-decoration: underline;
+  color: #ffffff;
+  background-color: rgba(255,255,255,0.08);
+  text-decoration: none;
 }
 
-.page-navigation .active {
-  font-weight: bold;
+.page-navigation .active a {
+  color: #ffffff;
+  font-weight: 700;
+  border-bottom: 3px solid #5ecb8f;
+  margin-bottom: -3px;
+}
+
+/* Profile icons */
+.profile-icons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 1rem 0;
 }
 
 .profile-icon {
-  display: inline;
-  font-size:32px;
-  padding-left: 25px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  background-color: #f4f4f4;
+  border-radius: 8px;
+  font-size: 24px;
+  color: #333;
+  transition: background-color 0.2s ease, color 0.2s ease, transform 0.15s ease;
+  text-decoration: none;
+}
+
+.profile-icon a {
+  color: #333;
+  text-decoration: none;
+}
+
+.profile-icon:hover {
+  background-color: #159957;
+  color: white;
+  transform: translateY(-2px);
+}
+
+.profile-icon:hover a {
+  color: white;
+}
+
+/* Skill tags */
+.skill-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 0.5rem 0 1rem;
+}
+
+.skill-tag {
+  display: inline-block;
+  padding: 4px 12px;
+  background-color: #eef6f0;
+  border: 1px solid #c8e6c9;
+  color: #2e7d32;
+  border-radius: 20px;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+/* Home page quick-links section */
+.quick-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin: 1.5rem 0;
+}
+
+/* Blog post list */
+.post-list {
+  margin-top: 1rem;
+}
+
+.post-category {
+  margin-bottom: 2rem;
+}
+
+.post-category ul {
+  padding-left: 0;
+  list-style: none;
+}
+
+.post-item {
+  padding: 0.75rem 0;
+  border-bottom: 1px solid #eaecef;
+}
+
+.post-item:last-child {
+  border-bottom: none;
+}
+
+.post-item a {
+  font-size: 16px;
+  font-weight: 600;
+  color: #155799;
+  text-decoration: none;
+}
+
+.post-item a:hover {
+  text-decoration: underline;
+  color: #0e3f70;
+}
+
+.post-date {
+  display: inline-block;
+  margin-left: 10px;
+  font-size: 13px;
+  color: #888;
+}
+
+.post-excerpt {
+  margin: 0.3rem 0 0;
+  font-size: 14px;
+  color: #606c71;
+}
+
+/* Responsive iframes */
+.iframe-wrapper {
+  max-width: 100%;
+  overflow-x: auto;
+  margin: 0.75rem 0 1.5rem;
+}
+
+.iframe-wrapper iframe {
+  max-width: 100%;
 }
 
 /** Consent Styles */
@@ -73,21 +220,58 @@
   bottom: 0;
   left: 0;
   width: 100%;
-  background: rgba(0, 0, 0, 0.8);
-  color: white;
-  padding: 10px;
+  background: rgba(0, 0, 0, 0.85);
+  color: #e0e0e0;
+  padding: 12px 20px;
   text-align: center;
   z-index: 1000;
-  display: none; /* Hidden by default */
+  display: none;
+  box-shadow: 0 -2px 8px rgba(0,0,0,0.3);
 }
+
+#consent-banner p {
+  margin: 0 0 8px;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
 #consent-banner button {
-  margin: 5px;
-  padding: 5px 10px;
+  margin: 4px 6px;
+  padding: 7px 18px;
   border: none;
-  background-color: #4CAF50;
+  border-radius: 4px;
+  background-color: #159957;
   color: white;
+  font-size: 14px;
+  font-weight: 500;
   cursor: pointer;
+  transition: background-color 0.2s ease;
 }
+
+#consent-banner button:hover {
+  background-color: #0c7b43;
+}
+
 #consent-banner button#consent-reject {
-  background-color: #f44336;
+  background-color: #757575;
+}
+
+#consent-banner button#consent-reject:hover {
+  background-color: #555;
+}
+
+/* Responsive nav */
+@media (max-width: 600px) {
+  .page-navigation {
+    padding: 0 0.5rem;
+  }
+
+  .page-navigation a {
+    padding: 12px 10px;
+    font-size: 13px;
+  }
+
+  .page-header {
+    padding: 10px 1rem;
+  }
 }

--- a/docs/blog.md
+++ b/docs/blog.md
@@ -6,24 +6,21 @@ description: 'Updates on our life, travels and work'
 
 ## Blog Posts
 
-Sharing about travel, life and projects! Just for fun and on no defined schedule.
+Sharing about travel, life and projects — just for fun and on no defined schedule.
 
 Personal posts will be shared here, while work-specific articles will be posted on Substack. [Subscribe to either or both at the bottom of this page.](#subscribe){: target="_top" }
 
-<div>
+<div class="post-list">
 {% for category in site.categories %}
-  <div>
+  <div class="post-category">
     {% capture category_name %}{{ category | first }}{% endcapture %}
     <h3>{{ category_name }}</h3>
     <ul>
     {% for post in site.categories[category_name] %}
-      <li>
-        <h3>
-          <a href="{{ site.baseurl }}{{ post.url }}" target="_top">
-            {{post.title}} | {{ post.date | date: "%d %b %Y" }}
-          </a>
-        </h3>
-        <p>{{post.excerpt}}</p>
+      <li class="post-item">
+        <a href="{{ site.baseurl }}{{ post.url }}" target="_top">{{ post.title }}</a>
+        <span class="post-date">{{ post.date | date: "%d %b %Y" }}</span>
+        <p class="post-excerpt">{{ post.excerpt }}</p>
       </li>
     {% endfor %}
     </ul>
@@ -31,11 +28,18 @@ Personal posts will be shared here, while work-specific articles will be posted 
 {% endfor %}
 </div>
 
+---
 
-### Subscribe
+### Subscribe {#subscribe}
 
 Subscribe to personal posts (via email):
-<iframe src="https://docs.google.com/forms/d/e/1FAIpQLSfdIcwi-4-jpWPz4mZ2jnFxgVJ6rP2vkp-ZXjoBrSlkE03A9A/viewform?embedded=true" width="640" height="450" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
 
-Subscribe to work-specific blog (via substack):
+<div class="iframe-wrapper">
+<iframe src="https://docs.google.com/forms/d/e/1FAIpQLSfdIcwi-4-jpWPz4mZ2jnFxgVJ6rP2vkp-ZXjoBrSlkE03A9A/viewform?embedded=true" width="640" height="450" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
+</div>
+
+Subscribe to work-specific blog (via Substack):
+
+<div class="iframe-wrapper">
 <iframe src="https://consultthedata.substack.com/embed" width="480" height="320" style="border:1px solid #EEE; background:white;" frameborder="0" scrolling="no"></iframe>
+</div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,10 +5,14 @@ title: Clan Conan
 
 ## About Me
 
-I'm Michael Conan - born and raised in Portland, Oregon and now living in Dublin, Ireland with my wife Marisa.
+I'm Michael Conan — born and raised in Portland, Oregon and now living in Dublin, Ireland with my wife Marisa.
 
-I currently work as a technology consultant for PricewaterhouseCoopers (PwC) in the Dublin Data, Analytics, and AI practice and Marisa recently worked at Intel and Gartner in Sales Operations roles.
+I work as a technology consultant for PricewaterhouseCoopers (PwC) in the Dublin Data, Analytics, and AI practice. Marisa has worked in Sales Operations roles at Intel and Gartner.
 
-Keep up with our life and travels by subscribing to my blog!
+This site is where we share updates on life, travel, and the occasional tech deep-dive.
 
-[Blog](/blog){: .my-button target="_top"}
+<div class="quick-links">
+  <a href="/blog" class="my-button" target="_top">Blog</a>
+  <a href="/profile" class="my-button my-button-secondary" target="_top">Profile</a>
+  <a href="/projects" class="my-button my-button-secondary" target="_top">Projects</a>
+</div>

--- a/docs/profile.md
+++ b/docs/profile.md
@@ -24,41 +24,50 @@ The largest projects I have worked on have been cloud data platform implementati
 
 Earlier in my consulting career I delivered many projects leveraging process automation technologies to streamline processes, primarily in the finance space.
 
-### Profile Links
+## Skills and Technologies
 
-Check out my other profiles and certifications:
+**Languages**
 
+<div class="skill-tags">
+  <span class="skill-tag">Python</span>
+  <span class="skill-tag">JavaScript</span>
+  <span class="skill-tag">SQL</span>
+  <span class="skill-tag">RPA</span>
+</div>
+
+**Cloud & Data Engineering**
+
+<div class="skill-tags">
+  <span class="skill-tag">Microsoft Azure</span>
+  <span class="skill-tag">Google Cloud Platform</span>
+  <span class="skill-tag">Databricks</span>
+  <span class="skill-tag">Snowflake</span>
+  <span class="skill-tag">SQL Server</span>
+</div>
+
+**Automation**
+
+<div class="skill-tags">
+  <span class="skill-tag">Google Apps Script</span>
+  <span class="skill-tag">UiPath</span>
+  <span class="skill-tag">Microsoft Power Automate</span>
+</div>
+
+**Analytics**
+
+<div class="skill-tags">
+  <span class="skill-tag">Alteryx</span>
+  <span class="skill-tag">Microsoft Power BI</span>
+  <span class="skill-tag">Tableau</span>
+  <span class="skill-tag">Microsoft Excel</span>
+</div>
+
+## Profiles & Certifications
+
+<div class="profile-icons">
 {% for entry in site.data.me.profiles %}
-  <div class="profile-icon">
-  <a href="{{ entry.href }}{{ entry.id }}" title="{{ entry.title }}">
+  <a class="profile-icon" href="{{ entry.href }}{{ entry.id }}" title="{{ entry.title }}" target="_blank" rel="noopener">
     <i class="{{ entry.icon }}"></i>
   </a>
-  </div>
 {% endfor %}
-
-### Skills and Technologies
-
-An quick list of some things I've learned through my career and education.
-
-- Languages
-  - Python
-  - JavaScript
-  - SQL
-  - Robotic Process Automation (RPA)
-- Technologies
-  - Cloud Computing
-    - Microsoft Azure
-    - Google Cloud Platform
-  - Data Engineering
-    - Databricks
-    - Snowflake
-    - SQL Server
-  - Automation
-    - Google Apps Script
-    - UiPath
-    - Microsoft Power Automate
-  - Analytics
-    - Alteryx
-    - Microsoft Power BI
-    - Tableau
-    - Microsoft Excel
+</div>

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -5,7 +5,10 @@ description: 'Summary of programming work I have completed and published'
 ---
 
 ## Projects
-Programming projects developed for personal productivity, training, or generic corporate tasks.
+
+Open-source projects developed for personal productivity, skills training, and reusable corporate tooling. Organized by technology.
+
+View all on [GitHub](https://github.com/michaelconan){: target="_blank" }.
 
 {% for topic in site.data.me.projects.topics %}
 #### {{ topic }}


### PR DESCRIPTION
## Summary

- Publishes new blog post: *Digital Toolbox: Management* — covering personal use of Jira, HubSpot, and Notion, plus AI agent integrations
- Site-wide UI refresh: improved navigation bar, skill tags, profile icons, post list styling, responsive iframe wrappers, and quick-links on the home page
- Adds `AGENTS.md` with project summary and agent guidance for blog revision and site enhancement; `CLAUDE.md` imports it via `@AGENTS.md`

## Test plan

- [x] Build site locally (`cd docs && bundle exec jekyll serve`) and verify all pages render without errors
- [x] Check blog listing shows new post under the `tech` category with correct date and excerpt
- [x] Verify navigation active state highlights correctly on each page
- [x] Check skill tags and profile icons display on the Profile page
- [x] Confirm subscription iframes are responsive on mobile viewport
- [x] Review `AGENTS.md` content is accurate and `CLAUDE.md` resolves via import

🤖 Generated with [Claude Code](https://claude.com/claude-code)